### PR TITLE
Support attachments in new messages

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -228,8 +228,8 @@
                  "Content-Type: application/json\r\n\r\n"
                  (jsexpr->string data))))
               (values
-               requester
-               (jsexpr->string data)))])
+               (jsexpr->string data)
+               requester))])
       (hash->message (run-route (make-route post "channels" "{channel-id}" "messages" #:channel-id channel-id)
                                 (struct-copy http-client (client-http-client client)
                                              [requester requester])


### PR DESCRIPTION
Adds the `#:file` keyword argument to `create-message` in `http`, and the `attachment` struct to pass to it.