### PR TITLE
edit-message: expose attachments array

### DIFF
--- a/http.rkt
+++ b/http.rkt
@@ -270,7 +270,8 @@
                                message-id
                                #:content [content null]
                                #:embed [single-embed null]
-                               #:embeds [embeds #f])
+                               #:embeds [embeds #f]
+                               #:attachments [attachments #f])
   (patch "channels" channel-id "messages" message-id)
   (define data (make-hash))
   (cond
@@ -284,6 +285,8 @@
      (hash-set! data 'embeds (list single-embed))])
   (unless (null? content)
     (hash-set! data 'content content))
+  (when attachments
+    (hash-set! data 'attachments attachments))
   #:data (json-payload data))
 
 (define/endpoint (delete-message _client channel-id message-id)


### PR DESCRIPTION
From [the documentation](https://discord.com/developers/docs/resources/message#edit-message):

>To remove or replace files you will have to supply the attachments field which specifies the files to retain on the message after edit.

In particular, this allows editing a message with an embed that referenced a file uploaded in the same message, *without the file now showing up outside the embed*. This issue had been previously [reported here](https://github.com/discord/discord-api-docs/issues/5675), and the workaround from one of the responses, translated to racket-cord:

```Racket
(http:edit-message myclient channel-id message-id #:embed updated-embed #:attachments null)
```

I think it's related to [this oddity](https://github.com/discord/discord-api-docs/issues/1340).

The way the Discord API handles attachments is not great IMO, but since racket-cord is pretty low level, I guess we should just expose it the way it is?